### PR TITLE
Ignore synthetic methods in Reflection.java

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
@@ -26,7 +26,7 @@ class Reflection {
     static <D extends DynamicObject<D>> Collection<Method> fieldGetters(Class<D> type) {
         Collection<Method> ret = new LinkedHashSet<>();
         for (Method method : type.getDeclaredMethods())
-            if (method.getParameterCount() == 0 && !method.isDefault() && !isMetadataGetter(method))
+            if (method.getParameterCount() == 0 && !method.isDefault() && !method.isSynthetic() && !isMetadataGetter(method))
                 ret.add(method);
         return ret;
     }


### PR DESCRIPTION
Ignoring compiler generated methods (and other tool-generated methods to support things like code coverage) as they will not have dynamic object annotations.