### PR TITLE
Improve DynamicObject support for Fressian caching

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/Cached.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/Cached.java
@@ -1,0 +1,14 @@
+package com.github.rschmitt.dynamicobject;
+
+import java.lang.annotation.*;
+
+/**
+ * Requests that DynamicObject serializers with support for caching or deduplicating repeated values cache the value
+ * stored under the associated getter or builder. Currently, only the Fressian serializer makes use of this annotation.
+ * <br>
+ * Yhis annotation does not impact binary compatibility of the serialized data.
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Cached {
+}

--- a/src/main/java/com/github/rschmitt/dynamicobject/FressianWriteHandler.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/FressianWriteHandler.java
@@ -1,9 +1,16 @@
 package com.github.rschmitt.dynamicobject;
 
-import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import org.fressian.CachedObject;
 import org.fressian.Writer;
 import org.fressian.handlers.WriteHandler;
+
+import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 
 public class FressianWriteHandler<D extends DynamicObject<D>> implements WriteHandler {
     private final Class<D> type;
@@ -17,7 +24,71 @@ public class FressianWriteHandler<D extends DynamicObject<D>> implements WriteHa
     @Override
     @SuppressWarnings("unchecked")
     public void write(Writer w, Object instance) throws IOException {
+        // We manually serialize the backing map so that we can apply caching transformations to specific subcomponents.
+        // To avoid needless copying we do this via an adapter rather than copying to a temporary list.
         w.writeTag(tag, 1);
-        w.writeObject(((DynamicObject) instance).getMap());
+        w.writeTag("map", 1);
+
+        Map map = ((DynamicObject)instance).getMap();
+        w.writeList(new ExplodingCollection(map, this::transformKey));
     }
+
+    private Object transformKey(Object key) {
+        // Although fressian will automatically cache the string components of each Keyword, by default we still
+        // spend a minimum of three bytes per keyword - one for the keyword directive itself, one for the namespace
+        // (usually null), and one for the cached reference to the keyword's string. By requesting caching of the
+        // Keyword object itself like this, we can get this down to one byte (after the initial cache miss).
+
+        // The downside of this is that cache misses incur additional an additional byte marking the key as
+        // being LRU-cache capable, and the cache misses will also result in two cache entries being introduced,
+        // causing more cache churn than there would be otherwise.
+
+        return new CachedObject(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    @RequiredArgsConstructor
+    private static class ExplodingCollection extends AbstractCollection {
+        final Map backingMap;
+        final Function<Object, Object> keysTransformation; // k -> k
+
+        @Override
+        public Iterator iterator() {
+            return new ExplodingIterator(backingMap.entrySet().iterator(), keysTransformation);
+        }
+
+        @Override
+        public int size() {
+            return backingMap.size() * 2;
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class ExplodingIterator implements Iterator {
+        final Iterator<Map.Entry> entryIterator;
+        final Function<Object, Object> keysTransformation; // k -> k
+
+        Optional<Object> pendingValue = Optional.empty();
+
+        @Override
+        public boolean hasNext() {
+            return pendingValue.isPresent() || entryIterator.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            if (pendingValue.isPresent()) {
+                Object value = pendingValue.get();
+                pendingValue = Optional.empty();
+
+                return value;
+            }
+
+            Map.Entry entry = entryIterator.next();
+            pendingValue = Optional.of(entry.getValue());
+
+            return keysTransformation.apply(entry.getKey());
+        }
+    }
+
 }

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/FressianSerialization.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/FressianSerialization.java
@@ -88,7 +88,7 @@ public class FressianSerialization {
 
     static synchronized <D extends DynamicObject<D>> void registerTag(Class<D> type, String tag) {
         binaryTagCache.put(type, tag);
-        Handlers.installHandler(fressianWriteHandlers, type, tag, new FressianWriteHandler(type, tag));
+        Handlers.installHandler(fressianWriteHandlers, type, tag, new FressianWriteHandler(type, tag, Reflection.cachedKeys(type)));
         fressianReadHandlers.putIfAbsent(tag, new FressianReadHandler(type));
     }
 

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
@@ -6,21 +6,25 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import com.github.rschmitt.dynamicobject.DynamicObject;
-import com.github.rschmitt.dynamicobject.Key;
-import com.github.rschmitt.dynamicobject.Meta;
-import com.github.rschmitt.dynamicobject.Required;
+import com.github.rschmitt.dynamicobject.*;
 
 class Reflection {
     static <D extends DynamicObject<D>> Collection<Method> requiredFields(Class<D> type) {
         Collection<Method> fields = fieldGetters(type);
         return fields.stream().filter(Reflection::isRequired).collect(Collectors.toSet());
+    }
+
+    static <D extends DynamicObject<D>> Set<Object> cachedKeys(Class<D> type) {
+        return Arrays.asList(type.getMethods()).stream()
+                .filter(method -> method.getAnnotation(Cached.class) != null)
+                .map(method -> method.getAnnotation(Key.class))
+                .filter(key -> key != null)
+                .map(Key::value)
+                .map(Reflection::stringToKey)
+                .collect(Collectors.toSet());
     }
 
     static <D extends DynamicObject<D>> Collection<Method> fieldGetters(Class<D> type) {

--- a/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
@@ -1,12 +1,17 @@
 package com.github.rschmitt.dynamicobject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.List;
 
 public class FressianTest {
 
@@ -41,7 +46,36 @@ public class FressianTest {
         assertEquals(SAMPLE_VALUE, deserialized);
     }
 
+    @Test
+    public void cachedKeys_canBeRoundTripped() throws Exception {
+        String cachedValue = "cached value";
+        BinarySerialized value = DynamicObject.newInstance(BinarySerialized.class).withCached(cachedValue);
+
+        byte[] fressian = DynamicObject.toFressianByteArray(Arrays.asList(value, value));
+        List<BinarySerialized> deserialized = (List<BinarySerialized>)DynamicObject.fromFressianByteArray(fressian);
+
+        assertEquals(value, deserialized.get(0));
+        assertEquals(value, deserialized.get(1));
+    }
+
+    @Test
+    public void cachedKeys_areNotRepeated() throws Exception {
+        String cachedValue = "cached value";
+        BinarySerialized value = DynamicObject.newInstance(BinarySerialized.class).withCached(cachedValue);
+
+        byte[] fressian = DynamicObject.toFressianByteArray(Arrays.asList(value, value));
+        // Interpret as an 8-bit charset just to make it easy to find the embedded string(s)
+        String s = new String(fressian, "ISO-8859-1");
+
+        int firstIndex = s.indexOf(cachedValue);
+        assertTrue(firstIndex >= 0);
+
+        int secondIndex = s.indexOf(cachedValue, firstIndex + 1);
+        assertEquals(-1, secondIndex);
+    }
+
     public interface BinarySerialized extends DynamicObject<BinarySerialized> {
         @Key(":hello") BinarySerialized withHello(String hello);
+        @Cached @Key(":cached") BinarySerialized withCached(String cached);
     }
 }

--- a/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
@@ -6,7 +6,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Base64;
+
 public class FressianTest {
+
+    public static final BinarySerialized SAMPLE_VALUE
+            = DynamicObject.newInstance(BinarySerialized.class).withHello("world");
+
     @Before
     public void setup() {
         DynamicObject.registerTag(BinarySerialized.class, "BinarySerialized");
@@ -19,12 +25,20 @@ public class FressianTest {
 
     @Test
     public void smokeTest() throws Exception {
-        BinarySerialized binarySerialized = DynamicObject.newInstance(BinarySerialized.class).withHello("world");
+        BinarySerialized binarySerialized = SAMPLE_VALUE;
 
         byte[] bytes = DynamicObject.toFressianByteArray(binarySerialized);
         Object o = DynamicObject.fromFressianByteArray(bytes);
 
         assertEquals(o, binarySerialized);
+    }
+
+    @Test
+    public void formatCompatibilityTest() throws Exception {
+        String encoded = "7+MQQmluYXJ5U2VyaWFsaXplZAHA5sr3zd9oZWxsb993b3JsZA==";
+        BinarySerialized deserialized = DynamicObject.fromFressianByteArray(Base64.getDecoder().decode(encoded));
+
+        assertEquals(SAMPLE_VALUE, deserialized);
     }
 
     public interface BinarySerialized extends DynamicObject<BinarySerialized> {


### PR DESCRIPTION
This pull request helps improve DynamicObject's use of Fressian caching by:

* Improving space efficiency of Keywords by caching the Keyword itself
* Exposing a new @Cached annotation to request Fressian caching of values in a DynamicObject data structure

These changes do not impact binary compatibility (in fact, none of the deserialization code is touched at all).