### PR TITLE
Fix DynamicObject.equals(null) throwing NPE

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
@@ -57,6 +57,9 @@ public abstract class DynamicObjectInstance<D extends DynamicObject<D>> extends 
 
     @Override
     public boolean equals(Object other) {
+        if (other == this) return true;
+        if (other == null) return false;
+
         if (other instanceof DynamicObject)
             return map.equals(((DynamicObject) other).getMap());
         else

--- a/src/test/java/com/github/rschmitt/dynamicobject/ObjectMethodsTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/ObjectMethodsTest.java
@@ -1,0 +1,16 @@
+package com.github.rschmitt.dynamicobject;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class ObjectMethodsTest {
+    @Test
+    public void equalsNullTest() throws Exception {
+        assertFalse(DynamicObject.newInstance(Something.class).equals(null));
+    }
+
+    public interface Something extends DynamicObject<Something> {
+
+    }
+}


### PR DESCRIPTION
Fixes rschmitt/dynamic-object#1 .