### PR TITLE
Fix map default methods being unusable on DO objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>net.fushizen.invokedynamic.proxy</groupId>
       <artifactId>invokedynamic-proxy</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/github/rschmitt/dynamicobject/MapTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/MapTest.java
@@ -52,6 +52,13 @@ public class MapTest {
         assertEquals(TaggedEdn, actualEdn);
     }
 
+    @Test
+    public void mapDefaultMethodsAreUsable() throws Exception {
+        EmptyObject object = DynamicObject.newInstance(EmptyObject.class);
+
+        object.getOrDefault("some key", "some value");
+    }
+
     private void binaryRoundTrip(Object expected) {
         Object actual = DynamicObject.fromFressianByteArray(DynamicObject.toFressianByteArray(expected));
         assertEquals(expected, actual);


### PR DESCRIPTION
Creating a pull request for comments & automated testing purposes. Since this is a trivial change I'll merge it in myself once it passes.