### PR TITLE
Equality override

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/Equality.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/Equality.java
@@ -1,0 +1,7 @@
+package com.github.rschmitt.dynamicobject;
+
+public interface Equality {
+     boolean isEqualTo(Object other);
+     
+     public int getHashCode();
+}

--- a/src/main/java/com/github/rschmitt/dynamicobject/Equality.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/Equality.java
@@ -1,6 +1,7 @@
 package com.github.rschmitt.dynamicobject;
 
 public interface Equality {
+    
      boolean isEqualTo(Object other);
      
      public int getHashCode();

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
@@ -1,6 +1,7 @@
 package com.github.rschmitt.dynamicobject.internal;
 
 import com.github.rschmitt.dynamicobject.DynamicObject;
+import com.github.rschmitt.dynamicobject.Equality;
 
 import java.io.StringWriter;
 import java.io.Writer;
@@ -52,15 +53,19 @@ public abstract class DynamicObjectInstance<D extends DynamicObject<D>> extends 
 
     @Override
     public int hashCode() {
-        return map.hashCode();
+        if(this instanceof Equality)
+           return ((Equality)this).getHashCode();
+        else
+           return map.hashCode();
     }
 
     @Override
     public boolean equals(Object other) {
         if (other == this) return true;
         if (other == null) return false;
-
-        if (other instanceof DynamicObject)
+        if(this instanceof Equality)
+            return ((Equality)this).isEqualTo(other);
+        else if (other instanceof DynamicObject)
             return map.equals(((DynamicObject) other).getMap());
         else
             return other.equals(map);

--- a/src/test/java/com/github/rschmitt/dynamicobject/EqualityTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/EqualityTest.java
@@ -1,23 +1,17 @@
 package com.github.rschmitt.dynamicobject;
 
 import static com.github.rschmitt.dynamicobject.DynamicObject.deserialize;
-import static com.github.rschmitt.dynamicobject.DynamicObject.newInstance;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
-
-import com.github.rschmitt.dynamicobject.CustomKeyTest.CustomBuilder;
 
 public class EqualityTest {
     @Test
     public void customBuilderSupport() {
         String edn1 = "{:firstName \"Tom\",:lastName \"Brady\",:ssn \"123456789\" }";
         String edn2 = "{:firstName \"Thomas\",:lastName \"Brady\",:ssn \"123456789\" }";
-
         Person person1 = deserialize(edn1, Person.class);
-        Person person2 = deserialize(edn1, Person.class);
-       
-
+        Person person2 = deserialize(edn2, Person.class);      
         assertEquals(person1, person2);
     }
     public interface Person extends DynamicObject<Person>,Equality {

--- a/src/test/java/com/github/rschmitt/dynamicobject/EqualityTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/EqualityTest.java
@@ -1,0 +1,48 @@
+package com.github.rschmitt.dynamicobject;
+
+import static com.github.rschmitt.dynamicobject.DynamicObject.deserialize;
+import static com.github.rschmitt.dynamicobject.DynamicObject.newInstance;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.github.rschmitt.dynamicobject.CustomKeyTest.CustomBuilder;
+
+public class EqualityTest {
+    @Test
+    public void customBuilderSupport() {
+        String edn1 = "{:firstName \"Tom\",:lastName \"Brady\",:ssn \"123456789\" }";
+        String edn2 = "{:firstName \"Thomas\",:lastName \"Brady\",:ssn \"123456789\" }";
+
+        Person person1 = deserialize(edn1, Person.class);
+        Person person2 = deserialize(edn1, Person.class);
+       
+
+        assertEquals(person1, person2);
+    }
+    public interface Person extends DynamicObject<Person>,Equality {
+        @Key(":firstName") String getFirstName();
+        @Key(":firstName") Person withFirstName(String firstName);
+        
+        @Key(":lastName") String getLastName();
+        @Key(":lastName") Person withLastName(String lastName);
+        
+        @Key(":ssn") String getSsn();
+        @Key(":ssn") Person withSsn(String ssn);
+        
+        default boolean isEqualTo(Object other){
+            if (other == this) return true;
+            if (other == null) return false;
+            if (other instanceof Person){
+                Person otherPerson=(Person)other;
+                return this.getSsn().equals(otherPerson.getSsn());
+            }else{
+                return equals(other);
+            }
+        }
+        
+        default int getHashCode(){
+            return getSsn().hashCode();
+        }
+    }
+}


### PR DESCRIPTION
I'm guessing this goes against some clojure principal but this change would allow object to override equals and hashcode by implementing the com.github.rschmitt.dynamicobject.Equality interface and adding default implementations of isEqualTo and getHashCode(). The com.github.rschmitt.dynamicobject.EqualityTest gives and example of when this sort of override would be useful.