### PR TITLE
Improvements to validate() performance

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
@@ -148,11 +148,6 @@ public abstract class DynamicObjectInstance<D extends DynamicObject<D>> extends 
         return this;
     }
 
-    public Object $$validate() {
-        Validation.validateInstance(this);
-        return $$customValidate();
-    }
-
     @Override
     public int size() {
         return map.size();

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/InvokeDynamicInvocationHandler.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/InvokeDynamicInvocationHandler.java
@@ -36,7 +36,7 @@ public class InvokeDynamicInvocationHandler implements DynamicInvocationHandler 
             return new ConstantCallSite(mh);
         }
         if ("validate".equals(methodName)) {
-            mh = lookup.findSpecial(DynamicObjectInstance.class, "$$validate", methodType(Object.class, new Class[]{}), proxyType).asType(methodType);
+            mh = Validation.buildValidatorFor(dynamicObjectType).asType(methodType);
         } else if ("$$customValidate".equals(methodName)) {
             try {
                 mh = lookup.findSpecial(dynamicObjectType, "validate", methodType(dynamicObjectType), proxyType);

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/Reflection.java
@@ -65,7 +65,9 @@ class Reflection {
     }
 
     private static boolean isAnyGetter(Method method) {
-        return method.getParameterCount() == 0 && !method.isDefault() && !method.isSynthetic();
+        return method.getParameterCount() == 0 && !method.isDefault() && !method.isSynthetic()
+                && (method.getModifiers() & Modifier.STATIC) == 0
+                && method.getReturnType() != Void.TYPE;
     }
 
     private static boolean isGetter(Method method) {

--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/Validation.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/Validation.java
@@ -1,155 +1,351 @@
 package com.github.rschmitt.dynamicobject.internal;
 
 import static java.lang.String.format;
+import static java.lang.invoke.MethodType.methodType;
 import static java.util.stream.Collectors.toList;
 
+import javax.annotation.CheckReturnValue;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.github.rschmitt.dynamicobject.DynamicObject;
 
 class Validation {
-    static <D extends DynamicObject<D>> void validateInstance(DynamicObjectInstance<D> instance) {
-        MethodObject<D> methodObject = new MethodObject<>();
-        methodObject.validate(instance, m -> {
-            Object key = Reflection.getKeyForBuilder(m);
-            return instance.getAndCacheValueFor(key, m.getGenericReturnType());
-        });
-        Collection<Method> missingFields = methodObject.missingFields;
-        Map<Method, Class<?>> mismatchedFields = methodObject.mismatchedFields;
-        if (!missingFields.isEmpty() || !mismatchedFields.isEmpty())
-            throw new IllegalStateException(methodObject.getValidationErrorMessage());
+
+    static <T extends DynamicObject<T>> MethodHandle buildValidatorFor(Class<T> klass) throws Exception {
+        return new ValidationBuilder<T>(klass).buildValidator().asType(methodType(klass, klass));
     }
 
-    static class MethodObject<D extends DynamicObject<D>> {
-        private final Collection<Method> missingFields = new LinkedHashSet<>();
-        private final Map<Method, Class<?>> mismatchedFields = new HashMap<>();
-        private Function<Method, Object> getter;
+    static class ValidationBuilder<T extends DynamicObject<T>> {
+        private static final MethodHandles.Lookup PRIVATE_LOOKUP = MethodHandles.lookup();
 
-        void validate(
-                DynamicObjectInstance<D> instance,
-                Function<Method, Object> getter
+        private final Class<T> dynamicObjectType;
+
+        ValidationBuilder(Class<T> dynamicObjectType) {
+            this.dynamicObjectType = dynamicObjectType;
+        }
+
+        // returns MH of type DynamicObject(DynamicObjectInstance)
+        public MethodHandle buildValidator() throws Exception {
+            List<FieldValidator> validators = new ArrayList<>();
+            Collection<Method> fields = Reflection.fieldGetters(dynamicObjectType);
+
+            try {
+                for (Method field : fields) {
+                    FieldInfo info = new FieldInfo(field);
+
+                    validators.add(buildValidator(info));
+                }
+
+                MethodHandle runCheck = PRIVATE_LOOKUP.findStatic(
+                        ValidationBuilder.class, "doValidate",
+                        MethodType.methodType(DynamicObject.class, DynamicObjectInstance.class, List.class)
+                );
+
+                return MethodHandles.insertArguments(runCheck, 1, validators);
+            } catch (Exception e) {
+                // Something is wrong with the class definition itself, so return a handle that always throws
+                return throwException(
+                        () -> {
+                            if (e instanceof UnsupportedOperationException) {
+                                return new UnsupportedOperationException(e.getMessage(), e);
+                            } else {
+                                return new UnsupportedOperationException(
+                                        "Validation failed due to structural error in DynamicObject type",
+                                        e
+                                );
+                            }
+                        },
+                        methodType(DynamicObject.class, DynamicObjectInstance.class)
+                );
+            }
+        }
+
+        @SuppressWarnings("unused") // invoked via reflection
+        private static DynamicObject<?> doValidate(
+                DynamicObjectInstance<?> instance,
+                List<FieldValidator> validators
         ) {
-            Collection<Method> fields = Reflection.fieldGetters(instance.getType());
-            this.getter = getter;
-            for (Method field : fields) {
-                Object key = Reflection.getKeyForGetter(field);
+            ValidationResult result = new ValidationResult();
+
+            for (FieldValidator validator : validators) {
+                validator.validate(instance, result);
+            }
+
+            result.checkResult();
+
+            return instance.$$customValidate();
+        }
+
+        private FieldValidator buildValidator(FieldInfo info) throws Exception {
+            // First, build a method handle that will perform the get, check for nulls, and perform a cast check if
+            // non-null
+            MethodHandle isNull = PRIVATE_LOOKUP.findStatic(
+                    Objects.class, "isNull", methodType(Boolean.TYPE, Object.class)
+            );
+
+            MethodHandle castChecker = MethodHandles.identity(Object.class);
+            castChecker = castChecker.asType(methodType(info.boxedType, info.boxedType));
+            // This second asType does not undo the first - we'll still attempt the cast to object and back.
+            castChecker = castChecker.asType(methodType(Object.class, Object.class));
+
+            MethodHandle castCheckIfNotNull = MethodHandles.guardWithTest(
+                    isNull, MethodHandles.identity(Object.class), castChecker
+            );
+
+            MethodHandle getAndCache = PRIVATE_LOOKUP.findVirtual(
+                    DynamicObjectInstance.class,
+                    "getAndCacheValueFor",
+                    methodType(Object.class, Object.class, Type.class)
+            );
+
+            getAndCache = MethodHandles.insertArguments(getAndCache, 1, info.key, info.genericType);
+
+            if (Reflection.getRawType(info.genericType) == Optional.class) {
+                // Unbox the Optional by invoking .orElse(null)
+                MethodHandle orElse = PRIVATE_LOOKUP.findVirtual(
+                        Optional.class,
+                        "orElse",
+                        methodType(Object.class, Object.class)
+                );
+
+                orElse = MethodHandles.insertArguments(orElse, 1, new Object[] { null });
+                orElse = orElse.asType(methodType(Object.class, Object.class));
+
+                getAndCache = MethodHandles.filterReturnValue(getAndCache, orElse);
+            }
+
+            MethodHandle checkedGet = MethodHandles.filterReturnValue(getAndCache, castCheckIfNotNull);
+
+            Consumer<Object> valueChecker = buildValueChecker(info.genericType);
+
+            return (instance, result) -> {
+                Object value;
                 try {
-                    validateField(field);
-                } catch (ClassCastException | AssertionError cce) {
-                    mismatchedFields.put(field, instance.getMap().get(key).getClass());
+                    value = checkedGet.invokeExact((DynamicObjectInstance)instance);
+                } catch (ClassCastException | AssertionError e) {
+                    result.mismatchedFields.put(info.getter, instance.getMap().get(info.key).getClass());
+                    return;
+                } catch (RuntimeException | Error e) {
+                    // usually some form of conversion error
+                    throw e;
+                } catch (Throwable t) {
+                    throw new IllegalStateException("Unexpected exception", t);
                 }
+
+                if (value == null) {
+                    if (info.isRequired) {
+                        result.missingFields.add(info.getter);
+                    }
+
+                    return;
+                }
+
+                valueChecker.accept(value);
+            };
+        }
+
+        private Consumer<Object> buildValueChecker(Type genericType) {
+            if (!isSupportedGenericType(genericType)) {
+                return throwingCheckerForUnsupportedType(genericType);
+            }
+
+            Class<?> rawType = Reflection.getRawType(genericType);
+
+            if (DynamicObject.class.isAssignableFrom(rawType)) {
+                return ValidationBuilder::checkDynamicObject;
+            } else if (Map.class.isAssignableFrom(rawType)) {
+                return buildMapChecker(genericType);
+            } else if (Collection.class.isAssignableFrom(rawType)) {
+                return buildCollectionChecker(genericType);
+            } else {
+                // no-op validator for types not known statically
+                return value -> {};
             }
         }
 
-        private void validateField(Method field) {
-            Object val = getter.apply(field);
-            if (Reflection.isRequired(field) && val == null)
-                missingFields.add(field);
-            if (val != null) {
-                Type genericReturnType = field.getGenericReturnType();
-                if (val instanceof Optional && ((Optional) val).isPresent()) {
-                    genericReturnType = Reflection.getTypeArgument(genericReturnType, 0);
-                    val = ((Optional) val).get();
-                }
-                Class<?> expectedType = Primitives.box(Reflection.getRawType(genericReturnType));
-                Class<?> actualType = val.getClass();
-                if (!expectedType.isAssignableFrom(actualType))
-                    mismatchedFields.put(field, actualType);
-                if (val instanceof DynamicObject)
-                    ((DynamicObject) val).validate();
-                else if (val instanceof List || val instanceof Set)
-                    validateCollection((Collection<?>) val, genericReturnType);
-                else if (val instanceof Map)
-                    validateMap((Map<?, ?>) val, genericReturnType);
+        private Consumer<Object> buildMapChecker(Type genericType) {
+            if (!(genericType instanceof ParameterizedType)) {
+                return value -> {};
             }
+
+            ParameterizedType parameterizedType = (ParameterizedType) genericType;
+            List<Type> typeArgs = Arrays.asList(parameterizedType.getActualTypeArguments());
+            assert typeArgs.size() == 2;
+
+            Type keyType = typeArgs.get(0);
+            Type valType = typeArgs.get(1);
+
+            Consumer<Object> keyChecker = buildElementChecker(keyType);
+            Consumer<Object> valChecker = buildElementChecker(valType);
+
+            return value -> {
+                Map m = (Map)value;
+
+                m.forEach((k, v) -> {
+                    keyChecker.accept(k);
+                    valChecker.accept(v);
+                });
+            };
         }
 
-        @SuppressWarnings("unchecked")
-        private void validateCollection(Collection<?> val, Type genericReturnType) {
-            if (val == null) return;
-            Class<?> baseCollectionType = Reflection.getRawType(genericReturnType);
-            if (!baseCollectionType.isAssignableFrom(val.getClass()))
-                throw new IllegalStateException(format("Wrong collection type: expected %s, got %s",
-                        baseCollectionType.getSimpleName(), val.getClass().getSimpleName()));
-            if (genericReturnType instanceof ParameterizedType) {
-                ParameterizedType parameterizedType = (ParameterizedType) genericReturnType;
+        private Consumer<Object> buildCollectionChecker(Type genericType) {
+            if (genericType instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) genericType;
                 List<Type> typeArgs = Arrays.asList(parameterizedType.getActualTypeArguments());
                 assert typeArgs.size() == 1;
 
                 Type typeArg = typeArgs.get(0);
-                checkTypeVariable(typeArg);
-                val.forEach(element -> checkElement(typeArg, element));
+
+                Consumer<Object> elementChecker = buildElementChecker(typeArg);
+                return value -> {
+                    for (Object elem : (Collection)value) {
+                        elementChecker.accept(elem);
+                    }
+                };
+            } else {
+                return value  -> {};
             }
         }
 
-        private void checkTypeVariable(Type typeArg) {
+        private Consumer<Object> buildElementChecker(Type genericType) {
+            if (!isSupportedGenericType(genericType)) {
+                return throwingCheckerForUnsupportedType(genericType);
+            }
+
+            Class<?> rawType = Reflection.getRawType(genericType);
+            Consumer<Object> checker = buildValueChecker(genericType);
+            MethodHandle castCheck = castChecker(rawType);
+
+            return value -> {
+                if (value != null) {
+                    try {
+                        castCheck.invokeExact(value);
+                    } catch (Throwable t) {
+                        throw new IllegalStateException(format("Expected collection element of type %s, got %s",
+                                                               rawType.getCanonicalName(),
+                                                               value.getClass().getCanonicalName()));
+                    }
+
+                    checker.accept(value);
+                }
+            };
+        }
+
+        private static void checkDynamicObject(Object value) {
+            ((DynamicObject)value).validate();
+        }
+
+        private Consumer<Object> throwingCheckerForUnsupportedType(Type genericType) {
+            if (genericType instanceof WildcardType) {
+                return value -> {
+                    throw new UnsupportedOperationException("Wildcard return types are not supported");
+                };
+            } else {
+                return value -> {
+                    throw new UnsupportedOperationException("Unknown generic type argument type: "
+                                                                    + genericType.getClass().getCanonicalName());
+                };
+            }
+        }
+
+        private boolean isSupportedGenericType(Type genericType) {
+            return (genericType instanceof ParameterizedType) || (genericType instanceof Class);
+        }
+
+        @CheckReturnValue
+        private Runnable checkTypeVariable(Type typeArg) {
             if (typeArg instanceof WildcardType)
-                throw new UnsupportedOperationException("Wildcard return types are not supported");
+                return () -> { throw new UnsupportedOperationException("Wildcard return types are not supported"); };
             else if (typeArg instanceof ParameterizedType)
-                return;
+                return () -> {};
             else if (typeArg instanceof Class)
-                return;
+                return () -> {};
             else
                 throw new UnsupportedOperationException("Unknown generic type argument type: " + typeArg.getClass().getCanonicalName());
         }
 
-        private void checkElement(Type elementType, Object element) {
-            if (elementType instanceof Class)
-                checkAtomicElement((Class<?>) elementType, element);
-            else
-                checkNestedElement(elementType, element);
+        // Returns an void(Object) MethodHandle that will throw if its argument cannot be cast to the specified type,
+        // and act as a no-op otherwise.
+        private static MethodHandle castChecker(Class<?> castTo) {
+            MethodHandle handle = MethodHandles.identity(castTo);
+            return handle.asType(methodType(Void.TYPE, Object.class));
         }
 
-        private void checkAtomicElement(Class<?> expectedType, Object element) {
-            if (element != null) {
-                Class<?> actualType = element.getClass();
-                if (!expectedType.isAssignableFrom(actualType))
-                    throw new IllegalStateException(format("Expected collection element of type %s, got %s",
-                            expectedType.getCanonicalName(),
-                            actualType.getCanonicalName()));
-                if (element instanceof DynamicObject)
-                    ((DynamicObject) element).validate();
+        // Returns a methodhandle of the specified type that ignores its arguments and throws a new exception given
+        // by the supplier specified.
+        private static MethodHandle throwException(Supplier<Throwable> supplier, MethodType type) throws Exception {
+            MethodHandle makeExn = PRIVATE_LOOKUP.findVirtual(Supplier.class, "get", methodType(Object.class));
+            makeExn = makeExn.bindTo(supplier);
+            makeExn = makeExn.asType(methodType(Throwable.class));
+
+            MethodHandle throwExn = MethodHandles.throwException(type.returnType(), Throwable.class);
+            throwExn = MethodHandles.foldArguments(throwExn, makeExn);
+
+            // discard arguments specified by the provided type
+            return MethodHandles.dropArguments(throwExn, 0, type.parameterArray());
+        }
+    }
+
+
+    @FunctionalInterface
+    private interface FieldValidator {
+        void validate(DynamicObjectInstance<?> instance, ValidationResult result);
+    }
+
+    private static class FieldInfo {
+        Method getter;
+        Object key;
+        Class<?> erasedType, boxedType;
+        Type genericType;
+        boolean isRequired;
+
+        public FieldInfo(Method getter) {
+            this.getter = getter;
+            key = Reflection.getKeyForGetter(getter);
+            genericType = getter.getGenericReturnType();
+            erasedType = Reflection.getRawType(genericType);
+
+            if (erasedType == Optional.class) {
+                // We'll unbox the Optional later on, but need to remember the true generic type for the
+                // initial get
+                erasedType = Reflection.getRawType(
+                        ((ParameterizedType)genericType).getActualTypeArguments()[0]
+                );
             }
+
+            boxedType = Primitives.box(erasedType);
+            isRequired = Reflection.isRequired(getter);
+        }
+    }
+
+    private static class ValidationResult {
+        private final Collection<Method> missingFields = new LinkedHashSet<>();
+        private final Map<Method, Class<?>> mismatchedFields = new HashMap<>();
+
+        void checkResult() {
+            if (!missingFields.isEmpty() || !mismatchedFields.isEmpty())
+                throw new IllegalStateException(getValidationErrorMessage());
         }
 
-        private void checkNestedElement(Type elementType, Object element) {
-            Class<?> rawType = Reflection.getRawType(elementType);
-            if (List.class.isAssignableFrom(rawType) || Set.class.isAssignableFrom(rawType))
-                validateCollection((Collection<?>) element, elementType);
-            else if (Map.class.isAssignableFrom(rawType))
-                validateMap((Map<?, ?>) element, elementType);
-            else
-                throw new UnsupportedOperationException("Unsupported base type " + rawType.getCanonicalName());
-        }
-
-        private void validateMap(Map<?, ?> map, Type genericReturnType) {
-            if (map == null) return;
-            if (genericReturnType instanceof ParameterizedType) {
-                ParameterizedType parameterizedType = (ParameterizedType) genericReturnType;
-                List<Type> typeArgs = Arrays.asList(parameterizedType.getActualTypeArguments());
-                assert typeArgs.size() == 2;
-
-                typeArgs.forEach(this::checkTypeVariable);
-                Type keyType = typeArgs.get(0);
-                Type valType = typeArgs.get(1);
-
-                map.keySet().forEach(k -> checkElement(keyType, k));
-                map.values().forEach(v -> checkElement(valType, v));
-            }
-        }
 
         String getValidationErrorMessage() {
             StringBuilder ret = new StringBuilder();
@@ -183,5 +379,7 @@ class Validation {
         private static String join(List<String> strings) {
             return strings.stream().collect(Collectors.joining(", "));
         }
+
     }
+
 }

--- a/src/test/java/com/github/rschmitt/dynamicobject/ValidationTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/ValidationTest.java
@@ -114,7 +114,9 @@ public class ValidationTest {
                           "Expected collection element of type java.math.BigInteger, got java.lang.String"
         );
         validationFailure("#LC{:list #{\"string!\" \"another string!\"}}", ListContainer.class,
-                          "Wrong collection type: expected List, got PersistentHashSet"
+                          "(Wrong collection type: expected List, got PersistentHashSet)|" +
+                                  "(The following fields had the wrong type:.*" +
+                                  "list \\(expected List, got PersistentHashSet\\))"
         );
         validationFailure("#LC{:inner [#I{:x 1}, #I{:x \"str\"}]}", ListContainer.class,
                           "The following fields had the wrong type:.*" +
@@ -267,6 +269,11 @@ public class ValidationTest {
     }
 
     @Test
+    public void strangeMethodsAreAccepted() throws Exception {
+        DynamicObject.deserialize("{}", HasWeirdMethods.class).validate();
+    }
+
+    @Test
     public void mutatingValidators() {
         MutatingValidator before = newInstance(MutatingValidator.class);
         MutatingValidator after = before.validate();
@@ -294,6 +301,14 @@ public class ValidationTest {
         assertEquals(edn, serialize(instance));
     }
 
+    @SuppressWarnings("unused")
+    public interface HasWeirdMethods extends DynamicObject<HasWeirdMethods> {
+        static void voidStatic() {}
+        static HasWeirdMethods voidReturning() { return null; }
+
+        default HasWeirdMethods returning() { return this; }
+        default void voidMethod() {}
+    }
 
     public interface NoRequiredFields extends DynamicObject<NoRequiredFields> {
         String s();


### PR DESCRIPTION
Currently, the validate() call spends most of its time working with the Java reflection API to analyze the structure of the class under validation. This change allows this heavy lifting to occur only once, at the time of the first validate call, and caches it thereafter.