### PR TITLE
Minor improvement to get performance

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/DynamicObjectInstance.java
@@ -140,7 +140,7 @@ public abstract class DynamicObjectInstance<D extends DynamicObject<D>> extends 
     }
 
     public Object getValueFor(Object key, Type genericReturnType) {
-        Object val = ClojureStuff.Get.invoke(map, key);
+        Object val = map.get(key);
         return Conversions.clojureToJava(val, genericReturnType);
     }
 


### PR DESCRIPTION
This improves get performance by bypassing some of the paths through Clojure Fns and instead using Java language APIs directly.

Note that this has a minor behavior change, in that getters returning types like List<> will return a ClojureFoo instead of an IPersistentFoo.