### PR TITLE
Only remove tag if present

### DIFF
--- a/src/main/java/com/github/rschmitt/dynamicobject/internal/FressianSerialization.java
+++ b/src/main/java/com/github/rschmitt/dynamicobject/internal/FressianSerialization.java
@@ -102,6 +102,8 @@ public class FressianSerialization {
     static synchronized <D extends DynamicObject<D>> void deregisterTag(Class<D> type) {
         String tag = binaryTagCache.remove(type);
         fressianWriteHandlers.remove(type);
-        fressianReadHandlers.remove(tag);
+        if (tag != null) {
+            fressianReadHandlers.remove(tag);
+        }
     }
 }

--- a/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
+++ b/src/test/java/com/github/rschmitt/dynamicobject/FressianTest.java
@@ -64,6 +64,15 @@ public class FressianTest {
     }
 
     @Test
+    public void deregisteringAClassRepeatedly_doesNotThrowAnNPE() throws Exception {
+        // First call to deregister & remove values from internal caches
+        DynamicObject.deregisterTag(BinarySerialized.class);
+
+        // This call should not throw an exception
+        DynamicObject.deregisterTag(BinarySerialized.class);
+    }
+
+    @Test
     public void cachedKeys_areNotRepeated() throws Exception {
         String cachedValue = "cached value";
         BinarySerialized value = DynamicObject.newInstance(BinarySerialized.class).withCached(cachedValue);


### PR DESCRIPTION
 ## Why is the change being made?
FressianSerialization#deregisterTag throws an exception if the tag is not present in the binaryTagCache.
This is because the returned value from binaryTagCache.remove(type) will be null, and fressianReadHandlers.remove(null) will throw an NPE.

 ## What has changed to address the problem?
Changed FressianSerialization's deregisterTag to check whether the tag is present before removing it from fressianReadHandlers. This keeps it consistent with EdnSerialization.

 ## How was this change tested?
Unit test added.